### PR TITLE
Small fix for systemjs.config.js

### DIFF
--- a/ng2Mvc5Demo/Scripts/systemjs.config.js
+++ b/ng2Mvc5Demo/Scripts/systemjs.config.js
@@ -5,14 +5,14 @@
 (function (global) {
     // map tells the System loader where to look for things
     var map = {
-        'app': 'Scripts', // 'dist',
-        '@angular': './libs/@angular',
-        'angular2-in-memory-web-api': './libs/angular2-in-memory-web-api',
-        'rxjs': './libs/rxjs'        
+        'app': '/Scripts', // 'dist',
+        '@angular': '/libs/@angular',
+        'angular2-in-memory-web-api': '/libs/angular2-in-memory-web-api',
+        'rxjs': '/libs/rxjs'        
     };
 
     var Materialmap = {        
-        '@angular2-material': './libs/@angular2-material'
+        '@angular2-material': '/libs/@angular2-material'
     };
 
 


### PR DESCRIPTION
With the original solution, Angular works only on the default route page (e.g.: http://localhost12345), but not on other routes (e.g.: http://localhost:12345/Home/About). I found out, that it was caused by bad file targeting in systemjs.config.js. In the original "./" case, all the different routed pages, are looking for the given files, relative to them (e.g.: http://localhost:12345/Home/About is looking for Angular files in http://localhost:12345/Home/About/libs/@angular), however, because of the gulping, these files are placed in a fix /lib folder. It is the same case with Scripts. The app should look for the /Scripts folder, located in the root. If we target these folders, Angular works great on all the routes.
